### PR TITLE
[comment] 댓글 작성시 modified_at이 created_at과 동일하게 기록되는 문제

### DIFF
--- a/src/main/kotlin/org/team14/webty/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/org/team14/webty/common/entity/BaseEntity.kt
@@ -4,7 +4,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
+//import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
@@ -19,7 +19,7 @@ open class BaseEntity {
     )
     var createdAt: LocalDateTime? = null
 
-    @LastModifiedDate
-    @Column(name = "modified_at", nullable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP")
+    //@LastModifiedDate
+    @Column(name = "modified_at", nullable = true)
     var modifiedAt: LocalDateTime? = null
 }

--- a/src/main/kotlin/org/team14/webty/reviewComment/entity/ReviewComment.kt
+++ b/src/main/kotlin/org/team14/webty/reviewComment/entity/ReviewComment.kt
@@ -29,13 +29,13 @@ class ReviewComment(
 
     // 댓글 작성자 정보 (지연 로딩)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    val user: WebtyUser? = null,
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: WebtyUser,
 
     // 댓글이 달린 리뷰 정보 (지연 로딩)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id")
-    val review: Review? = null,
+    @JoinColumn(name = "review_id", nullable = false)
+    val review: Review,
 
     // 댓글 내용 (필수 입력)
     @Column(name = "content", nullable = false)
@@ -53,10 +53,15 @@ class ReviewComment(
     @Column(name = "mentions", columnDefinition = "TEXT")
     var mentions: String = "[]"
 ) : BaseEntity() {
+        init {
+        this.modifiedAt = null  // 엔티티 생성 시 modifiedAt을 null로 초기화
+    }
+    
     // 댓글 내용과 멘션 목록을 업데이트하는 메소드
     fun updateComment(content: String, mentions: List<String>) {
         this.content = content
         this.mentions = mentions.joinToString(",")
+        this.modifiedAt = LocalDateTime.now() // 실제 수정 시에만 modifiedAt 설정
     }
 
     // 멘션 문자열을 리스트로 변환하는 메소드


### PR DESCRIPTION
Close #71 
![Image](https://github.com/user-attachments/assets/312c0624-773b-46c5-a150-e051c3c84de5)


![Image](https://github.com/user-attachments/assets/24c7ca82-ff38-418c-a030-3afbf593cca3)


이미지를 보면, 댓글 작성만 했을 뿐인데, DBeaver상에서 created_at의 시간과 동일하게 modified_at이 기록되고 있습니다. 이미지를 보면 알겠지만, 웹에서는 수정으로 인식하지 않아서 (수정됨) 이라는 글씨가 붙지 않는걸 보면, 댓글 작성을 수정으로 인식하는건 아닌것 같아요.

일단 나름대로 해결방법을 찾아봤는데, 이래도 테스트는 다 통과하더라구요. 이렇게 수정해도 괜찮다면 승인 부탁드릴께요.

세계님이 만드신 부분이 연관되어 있어서, @segye 님은 꼭 한번 봐주셨으면 좋겠습니다. 