### PR TITLE
feat: Websocket 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     // Swagger
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+    // WebSocket
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     // mockito-kotlin (test)
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
 }

--- a/src/main/kotlin/org/team14/webty/common/config/WebSocketConfig.kt
+++ b/src/main/kotlin/org/team14/webty/common/config/WebSocketConfig.kt
@@ -1,0 +1,24 @@
+package org.team14.webty.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+import org.team14.webty.common.interceptor.WebSocketAuthInterceptor
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.enableSimpleBroker("/topic") // 클라이언트 구독 엔드포인트
+        registry.setApplicationDestinationPrefixes("/app") // 클라이언트가 메시지 보낼때 사용
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/websocket") // 웹소켓 엔드포인트
+            .setAllowedOriginPatterns("*")
+            .addInterceptors(WebSocketAuthInterceptor())
+            .withSockJS()
+    }
+}

--- a/src/main/kotlin/org/team14/webty/common/interceptor/WebSocketAuthInterceptor.kt
+++ b/src/main/kotlin/org/team14/webty/common/interceptor/WebSocketAuthInterceptor.kt
@@ -1,0 +1,28 @@
+package org.team14.webty.common.interceptor
+
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.HandshakeInterceptor
+
+class WebSocketAuthInterceptor : HandshakeInterceptor {
+    override fun afterHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        exception: Exception?
+    ) {
+    }
+
+    override fun beforeHandshake( // 인증 정보 확인
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>
+    ): Boolean {
+        val authentication = SecurityContextHolder.getContext().authentication
+        attributes["user"] = authentication.principal
+        return true
+    }
+}

--- a/src/main/kotlin/org/team14/webty/voting/controller/WebSocketController.kt
+++ b/src/main/kotlin/org/team14/webty/voting/controller/WebSocketController.kt
@@ -1,0 +1,42 @@
+package org.team14.webty.voting.controller
+
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Controller
+import org.team14.webty.common.exception.BusinessException
+import org.team14.webty.common.exception.ErrorCode
+import org.team14.webty.security.authentication.WebtyUserDetails
+import org.team14.webty.voting.dto.VoteRequest
+import org.team14.webty.voting.service.VoteService
+
+@Controller
+class WebSocketController(
+    private val simpMessagingTemplate: SimpMessagingTemplate,
+    private val voteService: VoteService
+) { // SimpMessagingTemplate 주입
+
+    data class VotingResponse(val similarId: Long, val result: Long, val user: String)
+
+    @MessageMapping("/vote")
+    fun receiveVote(
+        @Payload voteRequest: VoteRequest,
+        headerAccessor: SimpMessageHeaderAccessor
+    ) {
+        val sessionAttributes = headerAccessor.sessionAttributes
+        val webtyUserDetails = sessionAttributes?.get("user") as? WebtyUserDetails
+            ?: throw BusinessException(ErrorCode.USER_NOT_FOUND)
+        val result = voteService.vote(webtyUserDetails, voteRequest)
+
+        println("VoteService 실행 완료 - similarId: ${voteRequest.similarId}, 현재 점수: $result") // VoteService 실행 로그
+
+        val response = VotingResponse(voteRequest.similarId, result, webtyUserDetails.webtyUser.nickname)
+
+        // 동적으로 채널로 메시지 전송
+        val destination = "/topic/vote-results/${voteRequest.similarId}"
+        simpMessagingTemplate.convertAndSend(destination, response) // 채널로 메시지 전송
+        println("WebSocket 메시지 전송 완료 - destination: $destination") // 메시지 전송 로그
+    }
+}
+


### PR DESCRIPTION
 const socket = new SockJS("http://localhost:8080/websocket", null, {
      withCredentials: true,
    });
이렇게 webSocket을 연결하고
 const voteRequest = { similarId: similarId, voteType: voteType };
      stompClient.publish({
        destination: "/app/vote",
        body: JSON.stringify(voteRequest),
      }); 
프론트에서 이런식으로 요청(publish)을 보내면 
백에서 처리후 /topic/vote-results/${voteRequest.similarId}로 메세지를 보내주면
client.subscribe(`/topic/vote-results/${similarId}`, (message) => { 
          const updatedVote = JSON.parse(message.body);
          console.log("실시간 투표 업데이트:", updatedVote);
          setVoteScore(updatedVote.result);
        }); 
프론트에서 이렇게 다시 subscribe를 통해 결과값을 받아옵니다