### PR TITLE
refactor: VoteController, VoteService

### DIFF
--- a/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
+++ b/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
@@ -25,7 +25,7 @@ class RedisSubscriber(
             val pageDto = objectMapper.readValue(messageBody, object : TypeReference<PageDto<SimilarResponse>>() {})
 
             // WebSocket을 통해 프론트로 전송
-            val destination = "/topic/vote-results/"
+            val destination = "/topic/vote-results/${pageDto.content.firstOrNull()?.targetWebtoonId ?: "default"}"
             simpMessagingTemplate.convertAndSend(destination, pageDto)
             destination
         }.onSuccess { destination ->

--- a/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
+++ b/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
@@ -25,7 +25,7 @@ class RedisSubscriber(
             val pageDto = objectMapper.readValue(messageBody, object : TypeReference<PageDto<SimilarResponse>>() {})
 
             // WebSocket을 통해 프론트로 전송
-            val destination = "/topic/vote-results/${pageDto.content.firstOrNull()?.similarId ?: "default"}"
+            val destination = "/topic/vote-results/"
             simpMessagingTemplate.convertAndSend(destination, pageDto)
             destination
         }.onSuccess { destination ->

--- a/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
+++ b/src/main/kotlin/org/team14/webty/common/redis/RedisSubscriber.kt
@@ -25,7 +25,7 @@ class RedisSubscriber(
             val pageDto = objectMapper.readValue(messageBody, object : TypeReference<PageDto<SimilarResponse>>() {})
 
             // WebSocket을 통해 프론트로 전송
-            val destination = "/topic/vote-results/${pageDto.content.firstOrNull()?.targetWebtoonId ?: "default"}"
+            val destination = "/topic/vote-results"
             simpMessagingTemplate.convertAndSend(destination, pageDto)
             destination
         }.onSuccess { destination ->

--- a/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheInitializer.kt
+++ b/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheInitializer.kt
@@ -13,6 +13,11 @@ class VoteCacheInitializer(
 
     override fun run(args: ApplicationArguments?) {
         val votes = voteRepository.findAll()
+
+        votes.forEach { vote ->
+            voteCacheService.setUserVote(vote.similar.similarId!!, vote.userId)
+        }
+
         votes.groupBy { it.similar.similarId!! to it.voteType }
             .forEach { (key, voteList) ->
                 val (similarId, voteType) = key

--- a/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheService.kt
+++ b/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheService.kt
@@ -31,6 +31,19 @@ class VoteCacheService(private val redisTemplate: RedisTemplate<String, String>)
         redisTemplate.opsForValue().set(key, count.toString())
     }
 
+    fun setUserVote(similarId: Long, userId: Long) { // 사용자별 투표 여부 저장
+        redisTemplate.opsForValue().set("vote:user:$userId:$similarId", "1")
+    }
+
+    fun hasUserVoted(similarId: Long, userId: Long): Boolean { // 사용자별 투표 여부 확인
+        return redisTemplate.opsForValue().get("vote:user:$userId:$similarId") != null
+    }
+
+    fun deleteUserVote(similarId: Long, userId: Long) {
+        val key = "vote:user:$userId:$similarId"
+        redisTemplate.delete(key)
+    }
+
     fun deleteVotesForSimilar(similarId: Long) { // 선택한 similar 관련 투표 전체 삭제
         VoteType.entries.forEach { voteType ->
             val key = getKey(similarId, voteType)

--- a/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheService.kt
+++ b/src/main/kotlin/org/team14/webty/voting/cache/VoteCacheService.kt
@@ -39,7 +39,7 @@ class VoteCacheService(private val redisTemplate: RedisTemplate<String, String>)
         return redisTemplate.opsForValue().get("vote:user:$userId:$similarId") != null
     }
 
-    fun deleteUserVote(similarId: Long, userId: Long) {
+    fun deleteUserVote(similarId: Long, userId: Long) { // 사용자별 투표 여부 삭제
         val key = "vote:user:$userId:$similarId"
         redisTemplate.delete(key)
     }

--- a/src/main/kotlin/org/team14/webty/voting/controller/VoteController.kt
+++ b/src/main/kotlin/org/team14/webty/voting/controller/VoteController.kt
@@ -4,46 +4,40 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
-import org.team14.webty.common.mapper.PageMapper
-import org.team14.webty.common.redis.RedisPublisher
 import org.team14.webty.security.authentication.WebtyUserDetails
-import org.team14.webty.voting.dto.VoteRequest
 import org.team14.webty.voting.service.VoteService
 
 @RestController
 @RequestMapping("/vote")
 class VoteController(
     private val voteService: VoteService,
-    private val redisPublisher: RedisPublisher
 ) {
     private val logger = KotlinLogging.logger {}
 
     // 투표
-    @PostMapping
+    @PostMapping("/{similarId}")
     fun vote(
         @AuthenticationPrincipal webtyUserDetails: WebtyUserDetails,
-        @RequestBody voteRequest: VoteRequest,
+        @PathVariable(value = "similarId") similarId: Long,
+        @RequestParam(value = "voteType") voteType: String,
         @RequestParam(defaultValue = "0", value = "page") page: Int,
         @RequestParam(defaultValue = "10", value = "size") size: Int,
     ): ResponseEntity<Void> {
-        val response =
-            voteService.vote(webtyUserDetails, voteRequest, page, size)
-        val responsePageDto =
-            PageMapper.toPageDto(response) // to do: voteService 에서 PageDto<SimilarResponse> 를 반환하도록 수정
-        logger.info { "VoteService 실행 로그" }
-
-        redisPublisher.publish("vote-results", responsePageDto)
-
+        voteService.vote(webtyUserDetails, similarId, voteType, page, size)
+        logger.info { "VoteService 투표 실행 로그" }
         return ResponseEntity.ok().build() // 응답은 WebSocket통해서 받아오므로 상태값만 전달
     }
 
-    // 투표 취소 // to do: 웹소켓으로 변경
-    @DeleteMapping("/{voteId}")
+    // 투표 취소
+    @DeleteMapping("/{similarId}")
     fun cancel(
         @AuthenticationPrincipal webtyUserDetails: WebtyUserDetails,
-        @PathVariable(value = "voteId") voteId: Long
+        @PathVariable(value = "similarId") similarId: Long,
+        @RequestParam(defaultValue = "0", value = "page") page: Int,
+        @RequestParam(defaultValue = "10", value = "size") size: Int
     ): ResponseEntity<Void> {
-        voteService.cancel(webtyUserDetails, voteId)
-        return ResponseEntity.ok().build()
+        voteService.cancel(webtyUserDetails, similarId, page, size)
+        logger.info { "VoteService 투표 취소 로그" }
+        return ResponseEntity.ok().build() // 응답은 WebSocket통해서 받아오므로 상태값만 전달
     }
 }

--- a/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
@@ -2,6 +2,7 @@ package org.team14.webty.voting.dto
 
 data class SimilarResponse(
     val similarId: Long,
+    val targetWebtoonId: Long,
     val similarThumbnailUrl: String,
     val similarResult: Long,
     val similarWebtoonId: Long, // webtoon-detail 페이지 이동 시 필요

--- a/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
@@ -4,7 +4,7 @@ data class SimilarResponse(
     val similarId: Long,
     val similarThumbnailUrl: String,
     val similarResult: Long,
-    val similarWebtoonId: Long // webtoon-detail 페이지 이동 시 필요
+    val similarWebtoonId: Long, // webtoon-detail 페이지 이동 시 필요
     val agreeCount: Long,
     val disagreeCount: Long
 )

--- a/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
@@ -5,4 +5,6 @@ data class SimilarResponse(
     val similarThumbnailUrl: String,
     val similarResult: Long,
     val similarWebtoonId: Long // webtoon-detail 페이지 이동 시 필요
+    val agreeCount: Long,
+    val disagreeCount: Long
 )

--- a/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/SimilarResponse.kt
@@ -2,7 +2,6 @@ package org.team14.webty.voting.dto
 
 data class SimilarResponse(
     val similarId: Long,
-    val targetWebtoonId: Long,
     val similarThumbnailUrl: String,
     val similarResult: Long,
     val similarWebtoonId: Long, // webtoon-detail 페이지 이동 시 필요

--- a/src/main/kotlin/org/team14/webty/voting/dto/VoteRequest.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/VoteRequest.kt
@@ -1,7 +1,0 @@
-package org.team14.webty.voting.dto
-
-data class VoteRequest(
-    val similarId: Long,
-    val voteType: String
-)
-

--- a/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
+++ b/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
@@ -17,7 +17,6 @@ object SimilarMapper {
     fun toResponse(similar: Similar, similarWebtoon: Webtoon, agreeCount: Long, disagreeCount: Long): SimilarResponse {
         return SimilarResponse(
             similarId = similar.similarId!!,
-            targetWebtoonId = similar.targetWebtoon.webtoonId!!,
             similarThumbnailUrl = similarWebtoon.thumbnailUrl,
             similarResult = similar.similarResult,
             similarWebtoonId = similarWebtoon.webtoonId!!,

--- a/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
+++ b/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
@@ -14,12 +14,14 @@ object SimilarMapper {
         )
     }
 
-    fun toResponse(similar: Similar, similarWebtoon: Webtoon): SimilarResponse {
+    fun toResponse(similar: Similar, similarWebtoon: Webtoon, agreeCount: Long, disagreeCount: Long): SimilarResponse {
         return SimilarResponse(
             similarId = similar.similarId!!,
             similarThumbnailUrl = similarWebtoon.thumbnailUrl,
             similarResult = similar.similarResult,
-            similarWebtoonId = similarWebtoon.webtoonId!!
+            similarWebtoonId = similarWebtoon.webtoonId!!,
+            agreeCount = agreeCount,
+            disagreeCount = disagreeCount
         )
     }
 }

--- a/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
+++ b/src/main/kotlin/org/team14/webty/voting/mapper/SimilarMapper.kt
@@ -17,6 +17,7 @@ object SimilarMapper {
     fun toResponse(similar: Similar, similarWebtoon: Webtoon, agreeCount: Long, disagreeCount: Long): SimilarResponse {
         return SimilarResponse(
             similarId = similar.similarId!!,
+            targetWebtoonId = similar.targetWebtoon.webtoonId!!,
             similarThumbnailUrl = similarWebtoon.thumbnailUrl,
             similarResult = similar.similarResult,
             similarWebtoonId = similarWebtoon.webtoonId!!,

--- a/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
+++ b/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
@@ -1,72 +1,66 @@
 package org.team14.webty.voting.service
 
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.team14.webty.common.exception.BusinessException
 import org.team14.webty.common.exception.ErrorCode
+import org.team14.webty.common.mapper.PageMapper
+import org.team14.webty.common.redis.RedisPublisher
 import org.team14.webty.security.authentication.AuthWebtyUserProvider
 import org.team14.webty.security.authentication.WebtyUserDetails
-import org.team14.webty.voting.dto.SimilarResponse
-import org.team14.webty.voting.dto.VoteRequest
 import org.team14.webty.voting.entity.Similar
-import org.team14.webty.voting.entity.Vote
 import org.team14.webty.voting.enums.VoteType
 import org.team14.webty.voting.mapper.SimilarMapper
 import org.team14.webty.voting.mapper.VoteMapper.toEntity
 import org.team14.webty.voting.repository.SimilarRepository
 import org.team14.webty.voting.repository.VoteRepository
 import org.team14.webty.webtoon.repository.WebtoonRepository
-import java.util.function.Supplier
 
 @Service
 class VoteService(
     private val voteRepository: VoteRepository,
     private val similarRepository: SimilarRepository,
     private val authWebtyUserProvider: AuthWebtyUserProvider,
-    private val webtoonRepository: WebtoonRepository
+    private val webtoonRepository: WebtoonRepository,
+    private val redisPublisher: RedisPublisher
 ) {
     // 유사 투표
     @Transactional
     fun vote(
         webtyUserDetails: WebtyUserDetails,
-        voteRequest: VoteRequest,
+        similarId: Long,
+        voteType: String,
         page: Int,
         size: Int
-    ): Page<SimilarResponse> {
+    ) {
         val pageable: Pageable = PageRequest.of(page, size)
         val webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails)
-        val similar = similarRepository.findById(voteRequest.similarId)
+        val similar = similarRepository.findById(similarId)
             .orElseThrow { BusinessException(ErrorCode.SIMILAR_NOT_FOUND) }!!
         // 중복 투표 방지
         if (voteRepository.existsByUserIdAndSimilar(webtyUser.userId!!, similar)) {
             throw BusinessException(ErrorCode.VOTE_ALREADY_EXISTS)
         }
-        val vote = toEntity(webtyUser, similar, voteRequest.voteType)
+        val vote = toEntity(webtyUser, similar, voteType)
         voteRepository.save(vote)
         updateSimilarResult(similar)
-        val similars = similarRepository.findAllByTargetWebtoon(similar.targetWebtoon, pageable)
-
-        // to do: 투표 결과 계산 및 이에 따라 정렬하여 PageDto<SimilarResponse> 를 반환하도록 수정
-        return similars.map { mapSimilar: Similar ->
-            SimilarMapper.toResponse(
-                mapSimilar,
-                webtoonRepository.findById(mapSimilar.similarWebtoonId)
-                    .orElseThrow { BusinessException(ErrorCode.WEBTOON_NOT_FOUND) }
-            )
-        }
+        publish(similar, pageable)
     }
 
     // 투표 취소
     @Transactional
-    fun cancel(webtyUserDetails: WebtyUserDetails, voteId: Long) {
-        authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails)
-        val vote: Vote = voteRepository.findById(voteId)
-            .orElseThrow(Supplier { BusinessException(ErrorCode.VOTE_NOT_FOUND) })
+    fun cancel(webtyUserDetails: WebtyUserDetails, similarId: Long, page: Int, size: Int) {
+        val pageable: Pageable = PageRequest.of(page, size)
+        val webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails)
+        val similar =
+            similarRepository.findById(similarId).orElseThrow { BusinessException(ErrorCode.SIMILAR_NOT_FOUND) }
+        val vote = voteRepository.findBySimilarAndUserId(similar, webtyUser.userId!!)
+            .orElseThrow { BusinessException(ErrorCode.VOTE_NOT_FOUND) }
         voteRepository.delete(vote)
         updateSimilarResult(vote.similar)
+        publish(similar, pageable)
     }
 
     private fun updateSimilarResult(existingSimilar: Similar) {
@@ -77,5 +71,21 @@ class VoteService(
         // similarResult 업데이트
         val updateSimilar = existingSimilar.copy(similarResult = agreeCount - disagreeCount)
         similarRepository.save<Similar>(updateSimilar)
+    }
+
+    private fun publish(
+        similar: Similar,
+        pageable: Pageable
+    ) {
+        val similars = similarRepository.findAllByTargetWebtoon(similar.targetWebtoon, pageable)
+        val similarResponsePageDto = similars.map { mapSimilar: Similar ->
+            SimilarMapper.toResponse(
+                mapSimilar,
+                webtoonRepository.findById(mapSimilar.similarWebtoonId)
+                    .orElseThrow { BusinessException(ErrorCode.WEBTOON_NOT_FOUND) }
+            )
+        }.let { PageMapper.toPageDto(it) }
+
+        redisPublisher.publish("vote-results", similarResponsePageDto)
     }
 }


### PR DESCRIPTION
투표 취소 로직 수행 결과를 웹소켓을 통해 프론트에 전달하도록 했고
VoteController에서 기존에 VoteRequest에 simialrId와 voteType을 전달했었는데 
투표 취소로직을 구현 하기 위해서는 similarId 값이 필요해 REST API 원칙을 준수하기 위해 similarId를 PathVaraible로 빼서 리팩토링 하였고 
VoteService에서 중복 되는 코드를 리팩토링 하였습니다.

프론트에서 테스트 결과 투표와 투표취소 모두 잘 작동함을 확인했고 실시간으로 투표결과가 업데이트 되는 것도 확인하였습니다.

또 VoteCachingService를 적용하여 DB에서 조회하는 부분을 Redis에서 조회하도록 리팩토링 하였습니다.

val destination = "/topic/vote-results/${pageDto.content.firstOrNull()?.targetWebtoonId ?: "default"}"
이부분을 이렇게 수정한 이유는 similarId로 Websocket을 구성하게 되면 만약 다른 유저가 다른 유사 웹툰에 투표했을 경우
그 업데이트된 내용을 구독하고 있지 않아 업데이트된 결과를 볼 수 없다고 생각하여 
"/topic/vote-results" 로 수정하였습니다

close #95 