### PR TITLE
feat: RedisBatch 추가

### DIFF
--- a/src/main/kotlin/org/team14/webty/common/config/ChannelConfig.kt
+++ b/src/main/kotlin/org/team14/webty/common/config/ChannelConfig.kt
@@ -1,0 +1,12 @@
+package org.team14.webty.common.config
+
+import kotlinx.coroutines.channels.Channel
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ChannelConfig {
+
+    @Bean
+    fun requestChannel(): Channel<Unit> = Channel(Channel.UNLIMITED)
+}

--- a/src/main/kotlin/org/team14/webty/common/redis/RedisBatch.kt
+++ b/src/main/kotlin/org/team14/webty/common/redis/RedisBatch.kt
@@ -1,0 +1,37 @@
+package org.team14.webty.common.redis
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PostConstruct
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+import org.team14.webty.voting.service.VoteService
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Component
+class RedisBatch(
+    private val voteService: VoteService
+) {
+    private val scope = CoroutineScope(Dispatchers.IO) // IO 최적화
+    private val isProcessing = AtomicBoolean(false) // 중복 실행 방지
+    private val logger = KotlinLogging.logger {}
+
+    @PostConstruct
+    fun startProcessing() {
+        voteService.onChangeCallback = {
+            if (isProcessing.compareAndSet(false, true)) { // 실행 중이 아니라면 실행
+                scope.launch {
+                    delay(100) // 100ms 동안 요청을 모은 후 실행
+                    logger.info { "변경 사항 감지됨, 배치 처리 실행" }
+                    val pageable: Pageable = PageRequest.of(0, 10)
+                    voteService.publish(pageable)
+                    isProcessing.set(false) // 처리 완료 후 다시 false로 설정
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/team14/webty/common/redis/RedisBatch.kt
+++ b/src/main/kotlin/org/team14/webty/common/redis/RedisBatch.kt
@@ -2,36 +2,52 @@ package org.team14.webty.common.redis
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.annotation.PostConstruct
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import org.team14.webty.voting.service.VoteService
-import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
 class RedisBatch(
-    private val voteService: VoteService
+    private val voteService: VoteService,
+    private val requestChannel: Channel<Unit> // 비동기 메세지 큐 역할
 ) {
-    private val scope = CoroutineScope(Dispatchers.IO) // IO 최적화
-    private val isProcessing = AtomicBoolean(false) // 중복 실행 방지
+    private val scope = CoroutineScope(Dispatchers.IO)
     private val logger = KotlinLogging.logger {}
+    private val mutex = Mutex() // 동시 접근 방지 (여러 코루틴 실행 X)
 
     @PostConstruct
     fun startProcessing() {
-        voteService.onChangeCallback = {
-            if (isProcessing.compareAndSet(false, true)) { // 실행 중이 아니라면 실행
-                scope.launch {
-                    delay(100) // 100ms 동안 요청을 모은 후 실행
-                    logger.info { "변경 사항 감지됨, 배치 처리 실행" }
-                    val pageable: Pageable = PageRequest.of(0, 10)
-                    voteService.publish(pageable)
-                    isProcessing.set(false) // 처리 완료 후 다시 false로 설정
+        scope.launch {
+            while (isActive) { // 실행 중이면 계속 대기
+                requestChannel.receive() // 최소 하나의 요청을 받을 때까지 대기
+
+                val startTime = System.currentTimeMillis() // 시작 시간 기록
+                var hasNewRequest = false
+
+                while (System.currentTimeMillis() - startTime < 100) { // 100ms 동안 추가 요청 감지
+                    delay(10) // 10ms마다 확인
+
+                    while (requestChannel.tryReceive().isSuccess) {
+                        hasNewRequest = true // 새로운 요청이 있으면 True 설정
+                    }
+                }
+
+                if (hasNewRequest) { // 새로운 요청이 있었다면 실행
+                    mutex.withLock {
+                        logger.info { "변경 사항 감지됨, 배치 처리 실행" }
+                        voteService.publish(PageRequest.of(0, 10)) // 한 번만 실행
+                    }
                 }
             }
         }
     }
 }
+
+
+
+
+

--- a/src/main/kotlin/org/team14/webty/search/service/SearchService.kt
+++ b/src/main/kotlin/org/team14/webty/search/service/SearchService.kt
@@ -3,16 +3,14 @@ package org.team14.webty.search.service
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.team14.webty.search.dto.SearchResponseDto
-import org.team14.webty.search.repository.SearchRepository
-import org.team14.webty.search.mapper.SearchResponseMapper
 import org.team14.webty.search.constants.SearchConstants
+import org.team14.webty.search.dto.SearchResponseDto
 import org.team14.webty.search.enums.SearchType
 import org.team14.webty.search.enums.SortType
+import org.team14.webty.search.mapper.SearchResponseMapper
+import org.team14.webty.search.repository.SearchRepository
 
 @Service
 class SearchService(
@@ -23,15 +21,15 @@ class SearchService(
 ) {
     private val log = LoggerFactory.getLogger(SearchService::class.java)
     private val searchExecutor = SearchExecutor(searchCacheService, searchResponseMapper)
-    
+
     /**
      * 검색 유형과 정렬 방식에 따라 검색을 수행합니다.
      */
     @Transactional(readOnly = true)
     suspend fun search(
-        keyword: String, 
-        page: Int, 
-        size: Int, 
+        keyword: String,
+        page: Int,
+        size: Int,
         searchType: SearchType = SearchType.ALL,
         sortType: SortType = SortType.LATEST
     ): SearchResponseDto = withContext(Dispatchers.IO) {
@@ -42,7 +40,7 @@ class SearchService(
             SearchType.REVIEW_CONTENT -> autocompleteService.addSearchKeywordToSuggestions(keyword)
             else -> autocompleteService.addSearchKeywordToSuggestions(keyword)
         }
-        
+
         // 검색 유형과 정렬 방식에 따라 적절한 검색 메서드 호출
         when (searchType) {
             SearchType.ALL -> {
@@ -52,6 +50,7 @@ class SearchService(
                     SortType.VIEW_COUNT -> searchAllOrderByViewCount(keyword, page, size)
                 }
             }
+
             SearchType.WEBTOON_NAME -> {
                 when (sortType) {
                     SortType.LATEST -> searchByWebtoonName(keyword, page, size)
@@ -59,6 +58,7 @@ class SearchService(
                     else -> searchByWebtoonName(keyword, page, size)
                 }
             }
+
             SearchType.NICKNAME -> {
                 when (sortType) {
                     SortType.LATEST -> searchByNickname(keyword, page, size)
@@ -66,6 +66,7 @@ class SearchService(
                     else -> searchByNickname(keyword, page, size)
                 }
             }
+
             SearchType.REVIEW_CONTENT -> {
                 when (sortType) {
                     SortType.LATEST -> searchByReviewContent(keyword, page, size)
@@ -75,100 +76,100 @@ class SearchService(
             }
         }
     }
-    
+
     /**
      * 일반 검색을 수행합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchAll(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchAll(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}${keyword}:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByKeyword(k, p)
         }
     }
-    
+
     /**
      * 추천수 기준으로 정렬된 검색을 수행합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchAllOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchAllOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}${keyword}:recommend:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByKeywordOrderByRecommendCount(k, p)
         }
     }
-    
+
     /**
      * 조회수 기준으로 정렬된 검색을 수행합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchAllOrderByViewCount(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchAllOrderByViewCount(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}${keyword}:viewCount:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByKeywordOrderByViewCount(k, p)
         }
     }
-    
+
     /**
      * 웹툰 이름으로 검색합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByWebtoonName(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByWebtoonName(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}webtoon:${keyword}:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByWebtoonName(k, p)
         }
     }
-    
+
     /**
      * 닉네임으로 검색합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByNickname(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByNickname(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}nickname:${keyword}:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByNickname(k, p)
         }
     }
-    
+
     /**
      * 웹툰 이름으로 검색하고 추천수로 정렬합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByWebtoonNameOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByWebtoonNameOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}webtoon:${keyword}:recommend:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByWebtoonNameOrderByRecommendCount(k, p)
         }
     }
-    
+
     /**
      * 닉네임으로 검색하고 추천수로 정렬합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByNicknameOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByNicknameOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}nickname:${keyword}:recommend:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByNicknameOrderByRecommendCount(k, p)
         }
     }
-    
+
     /**
      * 리뷰 내용 및 제목으로 검색합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByReviewContent(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByReviewContent(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}review:${keyword}:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByReviewContent(k, p)
         }
     }
-    
+
     /**
      * 리뷰 내용 및 제목으로 검색하고 추천수로 정렬합니다.
      */
     @Transactional(readOnly = true)
-    private suspend fun searchByReviewContentOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
+    suspend fun searchByReviewContentOrderByRecommendCount(keyword: String, page: Int, size: Int): SearchResponseDto {
         val cacheKey = "${SearchConstants.SEARCH_CACHE_KEY_PREFIX}review:${keyword}:recommend:${page}:${size}"
         return searchExecutor.executeSearch(keyword, page, size, cacheKey) { k, p ->
             searchRepository.searchByReviewContentOrderByRecommendCount(k, p)

--- a/src/main/kotlin/org/team14/webty/voting/repository/SimilarRepository.kt
+++ b/src/main/kotlin/org/team14/webty/voting/repository/SimilarRepository.kt
@@ -18,4 +18,7 @@ interface SimilarRepository : JpaRepository<Similar, Long> {
 
     @Query("SELECT s FROM Similar s WHERE s.targetWebtoon = :targetWebtoon ORDER BY s.similarResult DESC")
     fun findAllByTargetWebtoon(targetWebtoon: Webtoon, pageable: Pageable): Page<Similar>
+
+    @Query("SELECT s FROM Similar s ORDER BY s.similarResult DESC, s.similarId DESC")
+    fun findAllOrderBySimilarResultAndSimilarId(pageable: Pageable): Page<Similar>
 }


### PR DESCRIPTION
RedisBatch를 추가해서 동시에 여러 요청이 와도 여러 요청을 모두 처리한 후 여러개의 메세지가 나가는게 아니라 
하나의 메세지를 프론트에 전달하는 방식으로 작성하였습니다.
또한 publish 부분에서 similarResult가 제대로 업데이트가 되지 않는 문제가 발생했는데
원인은 redis를 통해 publish하는 속도가 DB에서 업데이트된 similarResult 값을 가져오는 속도보다 더 빨라서
업데이트된 similarResult값을 보내지 못하고 있었습니다.
그래서 copy를 통해 redis에 저장된 agreeCount와 disagreeCount를 통해 similarResult값을 업데이트 후 publish 하도록 수정하였습니다.

문제는 저희가 vote에 page,size를 받고있었는데 redisBatch에서 publish를 수행하다보니 page,size값을 controller에서 받아온 page,size값을 사용하지 못하는 문제가 있습니다.

그리고 진규님께서 작성하신 코드에서 @Transactional이 붙은 함수에 private이 붙어있으면 오류가나서 제거했습니다

이전 RedisBatch에서 처음 요청이 들어오면 100ms동안 delay를 하게 되는데 이때 새로 들어온 요청은 한번에 처리가 안되는 문제가 있었고
publish를 하는동안 새로운 요청이 오면 이 요청이 누락되는 문제가 있었습니다
그래서 Channel이라는 비동기 메세지 큐 역할을 하는 Channel을 사용해 100ms 동안 새로 들어온 요청까지 한번에 처리하도록 수정하였고
publish가 실행중이더라도 Channel에 계속 요청이 쌓이게 수정하였습니다
close #102 