### PR TITLE
dependency: modification for execution coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
     // kotlinx
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactive")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     // kotlin jackson
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.0")
 }

--- a/src/main/kotlin/org/team14/webty/search/repository/SearchQueryBuilder.kt
+++ b/src/main/kotlin/org/team14/webty/search/repository/SearchQueryBuilder.kt
@@ -22,6 +22,7 @@ object SearchQueryBuilder {
         WHERE (:keyword IS NULL OR 
             LOWER(w.webtoonName) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
             LOWER(r.content) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
+            LOWER(r.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR 
             LOWER(u.nickname) LIKE LOWER(CONCAT('%', :keyword, '%')))
     """
     


### PR DESCRIPTION
프론트에서 검색이 안되는 이유를 찾아서 의존성을 수정코자 합니다.
Close #106 

1. kotlinx-coroutines-reactive
- 코틀린 코루틴과 리액티브 스트림(Reactive Streams) API 간의 통합을 제공
- 비동기 프로그래밍을 위한 기본 브릿지 역할
2. kotlinx-coroutines-reactor
- Spring WebFlux에서 사용하는 Project Reactor와 코틀린 코루틴을 연결
- Mono와 Flux 타입을 코루틴과 함께 사용할 수 있게 해줌
- 백엔드 검색 컨트롤러에 있는 suspend fun search(...) 함수가 제대로 작동하는 데 필수적


코루틴이 kotlinx-coroutines-core:1.9.0만 있으면 안되는걸 몰랐네요.