### PR TITLE
Refactor : Voting 리팩토링 

### DIFF
--- a/src/main/kotlin/org/team14/webty/common/config/AsyncConfig.kt
+++ b/src/main/kotlin/org/team14/webty/common/config/AsyncConfig.kt
@@ -1,0 +1,8 @@
+package org.team14.webty.common.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+
+@Configuration
+@EnableAsync
+class AsyncConfig

--- a/src/main/kotlin/org/team14/webty/common/config/RedisConfig.kt
+++ b/src/main/kotlin/org/team14/webty/common/config/RedisConfig.kt
@@ -1,7 +1,6 @@
 package org.team14.webty.common.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.KotlinModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -13,8 +12,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer
 import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer
 import org.springframework.data.redis.serializer.StringRedisSerializer
-import org.team14.webty.common.redis.RedisSubscriber
-import org.team14.webty.review.entity.Review
+import org.team14.webty.voting.redis.RedisSubscriber
 
 /**
  * Redis 관련 설정을 담당하는 설정 클래스입니다.
@@ -31,7 +29,6 @@ class RedisConfig(
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
 
-    
 
     //-------------------
     // 투표 관련 설정
@@ -50,7 +47,7 @@ class RedisConfig(
     //-------------------
     // 검색 관련 설정
     //-------------------
-    
+
     /**
      * 검색용 RedisTemplate입니다.
      * 검색 결과 캐싱과 자동완성 기능에 사용됩니다.
@@ -58,22 +55,22 @@ class RedisConfig(
     @Bean(name = ["searchRedisTemplate"])
     fun searchRedisTemplate(objectMapper: ObjectMapper): RedisTemplate<String, Any> {
         val template = RedisTemplate<String, Any>()
-        template.setConnectionFactory(redisConnectionFactory())
-        
+        template.connectionFactory = redisConnectionFactory()
+
         val stringSerializer = StringRedisSerializer()
         template.keySerializer = stringSerializer
-        
+
         // 값은 JSON으로 직렬화하여 저장
         val jsonSerializer = Jackson2JsonRedisSerializer(objectMapper, Any::class.java)
         template.valueSerializer = jsonSerializer
-        
+
         template.hashKeySerializer = stringSerializer
         template.hashValueSerializer = jsonSerializer
-        
+
         template.afterPropertiesSet()
         return template
     }
-    
+
     /**
      * 투표 결과를 구독하기 위한 메시지 리스너 설정입니다.
      */

--- a/src/main/kotlin/org/team14/webty/voting/controller/VoteController.kt
+++ b/src/main/kotlin/org/team14/webty/voting/controller/VoteController.kt
@@ -24,7 +24,7 @@ class VoteController(
         @RequestParam(defaultValue = "0", value = "page") page: Int,
         @RequestParam(defaultValue = "10", value = "size") size: Int,
     ): ResponseEntity<Void> {
-        voteService.vote(webtyUserDetails, similarId, voteType, page, size)
+        voteService.vote(webtyUserDetails.webtyUser, similarId, voteType, page, size)
         logger.info { "VoteService 투표 실행 로그" }
         return ResponseEntity.ok().build() // 응답은 WebSocket통해서 받아오므로 상태값만 전달
     }
@@ -37,7 +37,7 @@ class VoteController(
         @RequestParam(defaultValue = "0", value = "page") page: Int,
         @RequestParam(defaultValue = "10", value = "size") size: Int
     ): ResponseEntity<Void> {
-        voteService.cancel(webtyUserDetails, similarId, page, size)
+        voteService.cancel(webtyUserDetails.webtyUser, similarId, page, size)
         logger.info { "VoteService 투표 취소 로그" }
         return ResponseEntity.ok().build() // 응답은 WebSocket통해서 받아오므로 상태값만 전달
     }
@@ -48,7 +48,7 @@ class VoteController(
         @AuthenticationPrincipal webtyUserDetails: WebtyUserDetails,
         @PathVariable(value = "similarId") similarId: Long
     ): ResponseEntity<VoteStatusResponse> {
-        val vote = voteService.getVoteStatus(webtyUserDetails, similarId)
+        val vote = voteService.getVoteStatus(webtyUserDetails.webtyUser, similarId)
         logger.info { "VoteService 투표 상태 조회 로그" }
         return ResponseEntity.ok(VoteStatusResponse(vote?.voteType?.name))
     }

--- a/src/main/kotlin/org/team14/webty/voting/dto/VoteFailureEvent.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/VoteFailureEvent.kt
@@ -1,6 +1,9 @@
 package org.team14.webty.voting.dto
 
+import org.team14.webty.voting.enums.VoteFailureType
+
 data class VoteFailureEvent(
     val similarId: Long,
-    val userId: Long
+    val userId: Long,
+    val voteFailureType: VoteFailureType
 )

--- a/src/main/kotlin/org/team14/webty/voting/dto/VoteFailureEvent.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/VoteFailureEvent.kt
@@ -1,0 +1,6 @@
+package org.team14.webty.voting.dto
+
+data class VoteFailureEvent(
+    val similarId: Long,
+    val userId: Long
+)

--- a/src/main/kotlin/org/team14/webty/voting/dto/VoteSuccessEvent.kt
+++ b/src/main/kotlin/org/team14/webty/voting/dto/VoteSuccessEvent.kt
@@ -1,0 +1,6 @@
+package org.team14.webty.voting.dto
+
+data class VoteSuccessEvent(
+    val similarId: Long,
+    val userId: Long
+)

--- a/src/main/kotlin/org/team14/webty/voting/entity/Vote.kt
+++ b/src/main/kotlin/org/team14/webty/voting/entity/Vote.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.*
 import org.team14.webty.voting.enums.VoteType
 
 @Entity
+@Table(name = "vote", uniqueConstraints = [UniqueConstraint(columnNames = ["userId", "similarId"])])
 class Vote(
     val userId: Long,
 

--- a/src/main/kotlin/org/team14/webty/voting/enums/VoteFailureType.kt
+++ b/src/main/kotlin/org/team14/webty/voting/enums/VoteFailureType.kt
@@ -1,0 +1,6 @@
+package org.team14.webty.voting.enums
+
+enum class VoteFailureType {
+    VOTE_FAILURE,
+    VOTE_CANCEL_FAILURE
+}

--- a/src/main/kotlin/org/team14/webty/voting/listener/VoteFailureEventListener.kt
+++ b/src/main/kotlin/org/team14/webty/voting/listener/VoteFailureEventListener.kt
@@ -1,0 +1,27 @@
+package org.team14.webty.voting.listener
+
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import org.team14.webty.voting.cache.VoteCacheService
+import org.team14.webty.voting.dto.VoteFailureEvent
+
+@Component
+class VoteFailureEventListener(
+    private val voteCacheService: VoteCacheService
+) {
+
+    private val log = LoggerFactory.getLogger(VoteFailureEventListener::class.java)
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
+    fun handleVoteFailureEvent(event: VoteFailureEvent) {
+        log.info("투표 처리 실패, 트랜잭션 롤백 similarId : {}, userId : {} ", event.similarId, event.userId)
+        voteCacheService.deleteUserVote(event.similarId, event.userId)
+    }
+}

--- a/src/main/kotlin/org/team14/webty/voting/listener/VoteFailureEventListener.kt
+++ b/src/main/kotlin/org/team14/webty/voting/listener/VoteFailureEventListener.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import org.team14.webty.voting.cache.VoteCacheService
 import org.team14.webty.voting.dto.VoteFailureEvent
+import org.team14.webty.voting.enums.VoteFailureType
 
 @Component
 class VoteFailureEventListener(
@@ -21,7 +22,22 @@ class VoteFailureEventListener(
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_ROLLBACK)
     fun handleVoteFailureEvent(event: VoteFailureEvent) {
-        log.info("투표 처리 실패, 트랜잭션 롤백 similarId : {}, userId : {} ", event.similarId, event.userId)
-        voteCacheService.deleteUserVote(event.similarId, event.userId)
+        log.info(
+            "투표 처리 실패, 트랜잭션 롤백 similarId : {}, userId : {} type: {}",
+            event.similarId,
+            event.userId,
+            event.voteFailureType
+        )
+
+        when (event.voteFailureType) {
+            // 투표 요청 실패 시 redis 유저 투표 내역 삭제
+            VoteFailureType.VOTE_FAILURE -> {
+                voteCacheService.deleteUserVote(event.similarId, event.userId)
+            }
+            // 투표 취소 실패 시 삭제된 투표 내역을 복구
+            VoteFailureType.VOTE_CANCEL_FAILURE -> {
+                voteCacheService.setUserVote(event.similarId, event.userId)
+            }
+        }
     }
 }

--- a/src/main/kotlin/org/team14/webty/voting/listener/VoteSuccessEventListener.kt
+++ b/src/main/kotlin/org/team14/webty/voting/listener/VoteSuccessEventListener.kt
@@ -1,0 +1,31 @@
+package org.team14.webty.voting.listener
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import org.team14.webty.voting.dto.VoteSuccessEvent
+
+@Component
+class VoteSuccessEventListener(
+    private val requestChannel: Channel<Unit>
+) {
+
+    private val log = LoggerFactory.getLogger(VoteSuccessEventListener::class.java)
+
+    @OptIn(DelicateCoroutinesApi::class)
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleVoteSuccessEvent(event: VoteSuccessEvent) {
+        log.info("투표 처리 성공, 배치 처리 시작 similarId : {}, userId : {} ", event.similarId, event.userId)
+        if (!requestChannel.isClosedForSend) {
+            requestChannel.trySend(Unit)
+        }
+    }
+}

--- a/src/main/kotlin/org/team14/webty/voting/redis/RedisPublisher.kt
+++ b/src/main/kotlin/org/team14/webty/voting/redis/RedisPublisher.kt
@@ -1,4 +1,4 @@
-package org.team14.webty.common.redis
+package org.team14.webty.voting.redis
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.github.oshai.kotlinlogging.KotlinLogging

--- a/src/main/kotlin/org/team14/webty/voting/redis/RedisSubscriber.kt
+++ b/src/main/kotlin/org/team14/webty/voting/redis/RedisSubscriber.kt
@@ -1,4 +1,4 @@
-package org.team14.webty.common.redis
+package org.team14.webty.voting.redis
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
+++ b/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
@@ -2,6 +2,7 @@ package org.team14.webty.voting.service
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Pageable
 import org.springframework.data.redis.RedisConnectionFailureException
 import org.springframework.data.repository.findByIdOrNull
@@ -140,6 +141,10 @@ class VoteService(
 
             is RedisConnectionFailureException -> {
                 logger.info { "Redis 연결 오류 발생" }
+            }
+
+            is DataIntegrityViolationException -> {
+                logger.info { "유니크 제약조건 위반 오류 발생" }
             }
 
             else -> {

--- a/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
+++ b/src/main/kotlin/org/team14/webty/voting/service/VoteService.kt
@@ -16,6 +16,7 @@ import org.team14.webty.voting.dto.VoteFailureEvent
 import org.team14.webty.voting.dto.VoteSuccessEvent
 import org.team14.webty.voting.entity.Similar
 import org.team14.webty.voting.entity.Vote
+import org.team14.webty.voting.enums.VoteFailureType
 import org.team14.webty.voting.enums.VoteType
 import org.team14.webty.voting.mapper.SimilarMapper
 import org.team14.webty.voting.mapper.VoteMapper.toEntity
@@ -62,7 +63,7 @@ class VoteService(
             eventPublisher.publishEvent(VoteSuccessEvent(similarId, webtyUser.userId!!))
         }.onFailure { e ->
             handleFailure(e)
-            eventPublisher.publishEvent(VoteFailureEvent(similarId, webtyUser.userId!!))
+            eventPublisher.publishEvent(VoteFailureEvent(similarId, webtyUser.userId!!, VoteFailureType.VOTE_FAILURE))
             throw e
         }
     }
@@ -84,7 +85,13 @@ class VoteService(
             eventPublisher.publishEvent(VoteSuccessEvent(similarId, webtyUser.userId!!))
         }.onFailure { e ->
             handleFailure(e)
-            eventPublisher.publishEvent(VoteFailureEvent(similarId, webtyUser.userId!!))
+            eventPublisher.publishEvent(
+                VoteFailureEvent(
+                    similarId,
+                    webtyUser.userId!!,
+                    VoteFailureType.VOTE_CANCEL_FAILURE
+                )
+            )
             throw e
         }
     }


### PR DESCRIPTION
멘토님께서 말씀하신대로 redis pub/sub 부분을 voting 폴더로 옮기고
VoteService에서 EventPublisher를 사용하는 방식으로 리팩토링을 진행했고 runCatching까지 없애고 싶었지만
트랜잭션이 실패했을경우 redis 캐시는 롤백되지 않기때문에 redis캐시 롤백을 위해 onFailure와 runCatching은 유지했습니다

Enum 타입을 하나 추가해서 투표 요청 실패와 투표 취소 실패를 구분하여 
VoteCacheService에서 각각에 맞는 작업을 하도록 리팩토링 하였습니다

그리고 Vote에 유니크 제약조건을 추가해 어제 멘토님이 말씀하신 상황에서도 중복 투표가 일어날 수 없도록 하였습니다.

close #126 