### PR TITLE
refactor Webtoon API crawler 향상

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,8 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.0")
     //elastic-search
     implementation ("org.springframework.data:spring-data-elasticsearch:5.4.0")
+    //WebClient
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
 }
 
 kotlin {

--- a/src/main/kotlin/org/team14/webty/common/config/WebClientConfig.kt
+++ b/src/main/kotlin/org/team14/webty/common/config/WebClientConfig.kt
@@ -1,0 +1,19 @@
+package org.team14.webty.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.ExchangeStrategies
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.builder()
+            .exchangeStrategies(
+                ExchangeStrategies.builder()
+                    .codecs { configure -> configure.defaultCodecs().maxInMemorySize(10 * 1024 * 1024) }
+                    .build())
+            .build()
+    }
+}

--- a/src/main/kotlin/org/team14/webty/webtoon/controller/WebtoonController.kt
+++ b/src/main/kotlin/org/team14/webty/webtoon/controller/WebtoonController.kt
@@ -21,7 +21,7 @@ class WebtoonController(
     private val webtoonService: WebtoonService
 ) {
     @GetMapping("/fetch") // 초기화 할 때만 사용
-    fun fetchWebtoons() {
+    suspend fun fetchWebtoons() {
         webtoonService.saveWebtoons()
     }
 

--- a/src/main/kotlin/org/team14/webty/webtoon/infrastructure/WebtoonApiWebClient.kt
+++ b/src/main/kotlin/org/team14/webty/webtoon/infrastructure/WebtoonApiWebClient.kt
@@ -1,0 +1,34 @@
+package org.team14.webty.webtoon.infrastructure
+
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.WebClient
+import org.team14.webty.webtoon.api.WebtoonPageApiResponse
+import org.team14.webty.webtoon.enums.Platform
+import org.team14.webty.webtoon.service.WebtoonService
+
+@Component
+class WebtoonApiClient(private val webClient: WebClient) {
+    companion object {
+        private const val URL_QUERY_TEMPLATE =
+            "https://korea-webtoon-api-cc7dda2f0d77.herokuapp.com/webtoons?page=%s&perPage=%s&sort=%s&provider=%s"
+    }
+    private val log = LoggerFactory.getLogger(WebtoonService::class.java)
+
+    suspend fun getWebtoonPageApiResponse(
+        page: Int, perPage: Int, sort: String, provider: Platform
+    ): WebtoonPageApiResponse? {
+        val url = String.format(URL_QUERY_TEMPLATE, page, perPage, sort, provider.platformName)
+        return try {
+            webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(WebtoonPageApiResponse::class.java)
+                .awaitSingleOrNull()
+        } catch (e: Exception) {
+            log.error("API 요청 실패 - URL: {}, Error: {}", url, e.message, e)
+            null
+        }
+    }
+}

--- a/src/main/kotlin/org/team14/webty/webtoon/schedueler/WebtoonScheduler.kt
+++ b/src/main/kotlin/org/team14/webty/webtoon/schedueler/WebtoonScheduler.kt
@@ -1,0 +1,31 @@
+package org.team14.webty.webtoon.schedueler
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.team14.webty.webtoon.enums.Platform
+import org.team14.webty.webtoon.service.WebtoonService
+
+@Component
+class WebtoonScheduler(
+    private val webtoonService: WebtoonService
+) {
+    private val log = LoggerFactory.getLogger(WebtoonScheduler::class.java)
+
+
+    @Scheduled(cron = "0 0 6 * * ?", zone = "Asia/Seoul")
+    fun updateWebtoons() {
+        runBlocking {
+            log.info("웹툰 데이터 업데이트 시작 (비동기)")
+            val start = System.currentTimeMillis()
+            Platform.values().map { provider ->
+                async { webtoonService.updateWebtoonsByProvider(provider) }
+            }.awaitAll()
+            val end = System.currentTimeMillis()
+            log.info("웹툰 데이터 업데이트 요청 완료 - 총 소요 시간: {} ms", (end - start))
+        }
+    }
+}


### PR DESCRIPTION
웹툰 크롤러 개선하면서 프로젝트 내의 웹툰 API 관련해서도 개선작업 이루어졌습니다.

전부 받아오는데 20초걸립니다.

그런데 외부 API와 통신하는 부분을 따로 빼는게 좋다고 말을 들었습니다.
(service는 비즈니스 로직만 해결해야 한다는 원칙?)

그것도 반영했습니다.