### PR TITLE
test: Modify Influxdb Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 
 ### 기타 ###
 **/naver-intellij-formatter.xml
+**/summary.json
 
 ### STS ###
 .apt_generated

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build/
 
 ### 기타 ###
 **/naver-intellij-formatter.xml
-**/summary.json
 
 ### STS ###
 .apt_generated

--- a/docker/webty-k6/docker-compose.k6.yml
+++ b/docker/webty-k6/docker-compose.k6.yml
@@ -77,14 +77,12 @@ services:
 
   influxdb:
     container_name: webty-k6-influxdb
-    image: influxdb:latest
+    image: influxdb:1.8
     restart: always
     environment:
       - INFLUXDB_ADMIN_USER=influx_admin
       - INFLUXDB_ADMIN_PASSWORD=influx_pw
       - INFLUXDB_DB=webty_k6_influx
-      - INFLUXDB_ORG=webty_team14
-      - INFLUXDB_BUCKET=webty_k6_influx
       - INFLUXDB_USER=influx_admin
       - INFLUXDB_PASSWORD=influx_pw
       - INFLUXDB_HTTP_BIND_ADDRESS=:8086
@@ -101,6 +99,7 @@ services:
     restart: always
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=grafana_admin
+      - GF_SERVER_HTTP_PORT=3001
     ports:
       - "3002:3001"
     depends_on:

--- a/src/test/k6/voting/similar-test.js
+++ b/src/test/k6/voting/similar-test.js
@@ -100,3 +100,10 @@ export function remove(data) {
     });
     sleep(0.2);
 }
+
+// ✅ 4️⃣ 테스트 결과 요약 (InfluxDB 저장)
+export function handleSummary(data) {
+    return {
+        "summary.json": JSON.stringify(data, null, 2), // JSON 저장
+    };
+}

--- a/src/test/k6/voting/similar-test.js
+++ b/src/test/k6/voting/similar-test.js
@@ -100,10 +100,3 @@ export function remove(data) {
     });
     sleep(0.2);
 }
-
-// ✅ 4️⃣ 테스트 결과 요약 (InfluxDB 저장)
-export function handleSummary(data) {
-    return {
-        "summary.json": JSON.stringify(data, null, 2), // JSON 저장
-    };
-}


### PR DESCRIPTION
# Grafana + InfluxDB 를 이용한 K6 시각화 도입

## 바뀐 부분
- docker-compose.k6.yml 수정: InfluxDB 버전 변경 
(아직까지 InfluxDB 2.x 버전은 grafana k6와 연동을 지원하지 않아 버전을 낮춤)

<br>

---

## 실행 방법

1. influxdb 컨테이너 및 influxdb:latest 이미지 삭제 

> 이미지 삭제는 필수는 아니지만 필요 없으므로 삭제합니다

> 도커 데스트탑에서 아래 컨테이너를 삭제합니다

![image](https://github.com/user-attachments/assets/8d706be6-f62a-46d0-ac38-751321b18259)

<br>

2. 도커 컴포즈 재실행

> 도커 컨테이너를 다시 만들어줍니다

```
docker-compose -f docker/webty-k6/docker-compose.k6.yml up --build
```

<br>

3. 테스트 실행

> 테스트 실행 시 결과가 influxDB에 저장되도록 실행합니다

```
docker exec -e K6_OUT=influxdb=http://webty-k6-influxdb:8086/webty_k6_influx -e K6_TOKEN=토큰을넣어주세요" webty-k6 k6 run /scripts/voting/similar-test.js
```

<br>

4. Grafana 사이트 접속

> 테스트 결과를 시각적으로 볼 수 있는 사이트에 접속합니다

```
http://localhost:3002/login

ID: admin
PW: grafana_admin
```

<br>

5. InfluxDB 연결

왼쪽 메뉴에서 Connections - influxdb

![image](https://github.com/user-attachments/assets/116bd73d-b40c-44fd-b928-a8a563b7c368)

<br>

6. Dashboard 생성

왼쪽 메뉴에서 Dashboards - Import dashboard - 2587 입력 후 LOAD 버튼

![image](https://github.com/user-attachments/assets/9a01fcae-15ed-4c3f-961f-fce746a54a31)

![image](https://github.com/user-attachments/assets/f3f968d7-c527-486f-b9b5-c0f3ac0963dd)

![image](https://github.com/user-attachments/assets/965a3edf-c6c4-4ce2-a5e9-437b363ce023)

참고: [K6 테스팅 결과 도구](https://grafana.com/grafana/dashboards/2587-k6-load-testing-results/)

<br>

---

close #124 